### PR TITLE
Add testing for Hive

### DIFF
--- a/tests/hive
+++ b/tests/hive
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+
+set -e
+
+rm -rf hive
+git clone https://github.com/apache/hive.git
+cd hive
+
+OPTS="-Phadoop-2 -Daccumulo-thrift.version=0.9.1 -Daccumulo.version=$1"
+
+for branch in "branch-1" "master"
+do
+  git checkout $branch
+
+  # Install hive
+  mvn install $OPTS -DskipTests
+
+  cd accumulo-handler
+  # Run accumulo-handler tests
+  mvn package $OPTS
+  cd ..
+
+  # Install the itests modules (detached from root pom)
+  cd itests
+  mvn install $OPTS -DskipTests
+
+  # Run the Accumulo tests
+  cd qtest-accumulo
+  mvn package $OPTS
+done


### PR DESCRIPTION
Simple test for the AccumuloStorageHandler in Hive. Looks like the end-to-end tests (in Hive parlance "itests") are broken (sigh) but just due to erroneous other output (the extraneous Hive output, not the result of the queries itself).

Running against 1.5, it also seems like I broke that somewhere along the line (but I'm not sure if I care anymore).

Feedback welcome.
